### PR TITLE
Custom generator struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,25 @@ De Goes is referring here to abstracting over type holes. Elixir is dynamically 
 In the cases that you _really need_ to override the prop checker, you have two options:
 
 ## `@force_type_class true`
-This will force the prop checker to pass for a particular instance
+This will force the prop checker to pass for all data types for the class.
+This is generally a bad idea (see section on principled classes above),
+but may be nessesary for some extreme edge cases.
+
+Using this option will trigger a compile time warning.
+
+## `@force_type_class true`
+This will force the prop checker to pass for a particular instance.
+
+This is sometimes needed, since TypeClass's property checker
+may not be able to accurately validate all data types correctly for
+all possible cases, especially when only subsets of built-in types are valid.
+(For example, a class that can only be deifned on 2-tuples).
+
+Forcing a type instance in this way is like telling
+the checker "trust me this is correct", and should only be used as
+a last resort. If at all possible, try to use `custom_generator/1` first.
+
+Using this option will trigger a compile time warning.
 
 ## `custom_generator/1`
 If you need to specify a certain type of data that conforms to the type class,
@@ -82,7 +100,9 @@ The generator must conform to the standard unary generator format.
 
 ```elixir
 definst AwesomeClass, for: Tuple do
-  custom_generator fn _ -> {generate(true), generate(1)}
+  custom_generator(a) do
+    {:always_two, a}
+  end
 
   # the rest as normal
   def awesome_level(_), do: 9000

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ but may be nessesary for some extreme edge cases.
 
 Using this option will trigger a compile time warning.
 
-## `@force_type_class true`
+## `@force_type_instance true`
 This will force the prop checker to pass for a particular instance.
 
 This is sometimes needed, since TypeClass's property checker

--- a/lib/type_class.ex
+++ b/lib/type_class.ex
@@ -167,17 +167,29 @@ defmodule TypeClass do
     [for: datatype] = opts
 
     quote do
+      instance = Module.concat([unquote(class), Proto, unquote(datatype)])
+
       defimpl unquote(class).Proto, for: unquote(datatype) do
         import TypeClass.Property.Generator.Custom
 
         @doc false
         def __custom_generator__, do: false
-        defoverridable [__custom_generator__: 0]
+
+        Module.register_attribute(__MODULE__, :force_type_class, [])
+        @force_type_instance false
+
+        @doc false
+        def __force_type_instance__, do: @force_type_instance
+
+        defoverridable [
+          __custom_generator__:   0,
+          __force_type_instance__: 0
+        ]
 
         unquote(body)
       end
 
-      unless unquote(class).__force_type_class__() do
+      unless unquote(class).__force_type_class__() or instance.__force_type_instance__() do
         unquote(datatype) |> conforms(to: unquote(class))
       end
     end

--- a/lib/type_class.ex
+++ b/lib/type_class.ex
@@ -178,19 +178,42 @@ defmodule TypeClass do
         Module.register_attribute(__MODULE__, :force_type_class, [])
         @force_type_instance false
 
-        @doc false
-        def __force_type_instance__, do: @force_type_instance
-
-        defoverridable [
-          __custom_generator__:   0,
-          __force_type_instance__: 0
-        ]
+        defoverridable [__custom_generator__: 0]
 
         unquote(body)
+
+        @doc false
+        def __force_type_instance__, do: @force_type_instance
       end
 
-      unless unquote(class).__force_type_class__() or instance.__force_type_instance__() do
-        unquote(datatype) |> conforms(to: unquote(class))
+      cond do
+        unquote(class).__force_type_class__() ->
+          IO.warn """
+          The type class #{unquote(class)} has been forced to bypass \
+          all property checks for all data types. This is very rarely valid, \
+          as all type classes should have properties associted with them.
+
+          For more, please see the TypeClass README:
+          https://github.com/expede/type_class/blob/master/README.md
+          """
+
+        instance.__force_type_instance__() ->
+          IO.warn """
+          The data type #{unquote(datatype)} has been forced to skip property \
+          validation for the type class #{unquote(class)}
+
+          This is sometimes valid, since TypeClass's property checker \
+          may not be able to accurately validate all data types correctly for \
+          all possible cases. Forcing a type instance in this way is like telling \
+          the checker "trust me this is correct", and should only be used as \
+          a last resort.
+
+          For more, please see the TypeClass README:
+          https://github.com/expede/type_class/blob/master/README.md
+          """
+
+        true ->
+          unquote(datatype) |> conforms(to: unquote(class))
       end
     end
   end

--- a/lib/type_class.ex
+++ b/lib/type_class.ex
@@ -129,8 +129,11 @@ defmodule TypeClass do
   defmacro defclass(class_name, do: body) do
     quote do
       defmodule unquote(class_name) do
-        import TypeClass.Property.GeneratorHelper
+        import TypeClass.Property.Generator, only: [generate: 1]
+        import TypeClass.Property.Generator.Custom
+
         require TypeClass.Property
+
         use TypeClass.Dependency
 
         Module.register_attribute(__MODULE__, :force_type_class, [])
@@ -232,7 +235,7 @@ defmodule TypeClass do
         For this type class's API, please refer to `#{unquote(class)}`
         """
 
-        import TypeClass.Property.GeneratorHelper
+        import TypeClass.Property.Generator.Custom
 
         Macro.escape unquote(fun_specs), unquote: true
       end

--- a/lib/type_class.ex
+++ b/lib/type_class.ex
@@ -165,7 +165,7 @@ defmodule TypeClass do
 
     quote do
       defimpl unquote(class).Proto, for: unquote(datatype) do
-        import TypeClass.Property.GeneratorHelper, only: [custom_generator: 1]
+        import TypeClass.Property.Generator.Custom
 
         @doc false
         def __custom_generator__, do: false

--- a/lib/type_class/property.ex
+++ b/lib/type_class/property.ex
@@ -25,7 +25,7 @@ defmodule TypeClass.Property do
 
     data_generator =
       if custom_generator do
-        {:CUSTOM_GENERATOR, custom_generator}
+        custom_generator
       else
         TC.append(TypeClass.Property.Generator, datatype).generate(nil)
       end

--- a/lib/type_class/property/generator.ex
+++ b/lib/type_class/property/generator.ex
@@ -43,11 +43,14 @@ defimpl TypeClass.Property.Generator, for: Any do
   end
 end
 
-defimpl TypeClass.Property.Generator for: TypeClass.Property.Generator.Custom do
+defimpl TypeClass.Property.Generator, for: TypeClass.Property.Generator.Custom do
   @moduledoc false
 
-  def generate(generator), do: generate(generator, nil)
-  def generate(generator, seed), do: generator.(seed)
+  def generate(generator) do
+    generate(generator, TypeClass.Property.Generator.generate(nil))
+  end
+
+  def generate(%{generator: generator}, seed), do: generator.(seed)
 end
 
 defimpl TypeClass.Property.Generator, for: Function do

--- a/lib/type_class/property/generator.ex
+++ b/lib/type_class/property/generator.ex
@@ -28,22 +28,6 @@ defprotocol TypeClass.Property.Generator do
   def generate(sample)
 end
 
-defmodule TypeClass.Property.GeneratorHelper do
-  @moduledoc "Helpers for handling generator values. Defaultys, overrides, &c"
-
-  @spec generate(any()) :: any()
-  def generate({:CUSTOM_GENERATOR, generator}), do: generator.(nil)
-  def generate(sample), do: TypeClass.Property.Generator.generate(sample)
-
-  @doc "Define a hidden `__cutsom_generator__/1` function"
-  defmacro custom_generator(generator) do
-    quote do
-      @doc false
-      def __custom_generator__, do: unquote(generator)
-    end
-  end
-end
-
 defimpl TypeClass.Property.Generator, for: Any do
   @moduledoc false
 
@@ -57,6 +41,13 @@ defimpl TypeClass.Property.Generator, for: Any do
     |> Enum.random()
     |> TypeClass.Property.Generator.generate()
   end
+end
+
+defimpl TypeClass.Property.Generator for: TypeClass.Property.Generator.Custom do
+  @moduledoc false
+
+  def generate(generator), do: generate(generator, nil)
+  def generate(generator, seed), do: generator.(seed)
 end
 
 defimpl TypeClass.Property.Generator, for: Function do

--- a/lib/type_class/property/generator/custom.ex
+++ b/lib/type_class/property/generator/custom.ex
@@ -1,0 +1,20 @@
+defmodule TypeClass.Property.Generator.Custom do
+  @moduledoc "Internal representation of a custom generator"
+
+  @type t :: TypeClass.Property.Generator.Custom{generator: fun()}
+  defstruct generator: &Quark.id/1
+
+  @doc "Define a hidden `__cutsom_generator__/1` function"
+  defmacro custom_generator(arg, do: body) do
+    quote do
+      @doc false
+      def __custom_generator__(_) do
+        %TypeClass.Property.Generator.Custom{
+          generator: fn unquote(arg) ->
+            unquote(body)
+          end
+        }
+      end
+    end
+  end
+end

--- a/lib/type_class/property/generator/custom.ex
+++ b/lib/type_class/property/generator/custom.ex
@@ -1,14 +1,16 @@
 defmodule TypeClass.Property.Generator.Custom do
   @moduledoc "Internal representation of a custom generator"
 
-  @type t :: TypeClass.Property.Generator.Custom{generator: fun()}
+  alias __MODULE__
+
+  @type t :: %TypeClass.Property.Generator.Custom{generator: fun()}
   defstruct generator: &Quark.id/1
 
   @doc "Define a hidden `__cutsom_generator__/1` function"
   defmacro custom_generator(arg, do: body) do
     quote do
       @doc false
-      def __custom_generator__(_) do
+      def __custom_generator__ do
         %TypeClass.Property.Generator.Custom{
           generator: fn unquote(arg) ->
             unquote(body)

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule TypeClass.Mixfile do
       name: "TypeClass",
       description: "(Semi-)principled type classes for Elixir",
 
-      version: "1.1.0",
+      version: "1.1.1",
       elixir:  "~> 1.4",
 
       package: [

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule TypeClass.Mixfile do
       name: "TypeClass",
       description: "(Semi-)principled type classes for Elixir",
 
-      version: "1.1.1",
+      version: "1.2.0",
       elixir:  "~> 1.4",
 
       package: [

--- a/spec/type_class_spec.exs
+++ b/spec/type_class_spec.exs
@@ -221,7 +221,10 @@ defmodule TypeClassSpec do
     end
 
     definst Only2Tuple, for: Tuple do
-      custom_generator fn _ -> {1, 2} end
+      custom_generator(a) do
+        {:always_two, a}
+      end
+
       def second({_a, b}), do: b
     end
   end

--- a/spec/type_class_spec.exs
+++ b/spec/type_class_spec.exs
@@ -206,6 +206,31 @@ defmodule TypeClassSpec do
     end
   end
 
+  describe "force instance" do
+    defclass GoodClassBadInst do
+
+      where do
+        def my_div(num_a, num_b)
+      end
+
+      properties do
+        def usually_good_but_hard_for_floats(data) do
+          a = generate(data)
+          GoodClassBadInst.my_div(a * a, a) == a # `==` so that we force the floats to disagree
+        end
+      end
+    end
+
+    definst GoodClassBadInst, for: Integer do
+      def my_div(int_a, int_b), do: int_a / int_b
+    end
+
+    definst GoodClassBadInst, for: Float do
+      @force_type_instance true
+      def my_div(float_a, float_b), do: float_a / float_b
+    end
+  end
+
   describe "custom generator" do
     defclass Only2Tuple do
       where do


### PR DESCRIPTION
Using a tagged tuple cased the generator all kinds of edge cases. Falling back to structs. Performance penalty is only at compile time, so whatevs.

Also added a `@force_type_instance` option to skip validation for single instances, and updated README with reasoning.