### PR TITLE
Use ExUnit.Assertions for evalutating the comparisons

### DIFF
--- a/lib/type_class/property.ex
+++ b/lib/type_class/property.ex
@@ -47,10 +47,11 @@ defmodule TypeClass.Property do
   """
   @spec equal?(any(), any()) :: boolean()
   def equal?(left, right) do
+    import ExUnit.Assertions
     cond do
-      is_function(left) -> left.("foo") == right.("foo")
-      is_float(left)    -> Float.round(left, 5) == Float.round(right, 5)
-      true              -> left == right
+      is_function(left) -> assert left.("foo") == right.("foo")
+      is_float(left)    -> assert Float.round(left, 5) == Float.round(right, 5)
+      true              -> assert left == right
     end
   end
 end


### PR DESCRIPTION
When equals fails, nobody knows which of the currently three branches failed and which values differed. The assertion macros form ExUnit have exactly this capability and using them reveals what is going wrong. 