### PR TITLE
HOTFIX: equal?/2 should not assert

### DIFF
--- a/lib/type_class/property.ex
+++ b/lib/type_class/property.ex
@@ -50,9 +50,9 @@ defmodule TypeClass.Property do
     import ExUnit.Assertions
 
     cond do
-      is_function(left) -> assert left.("foo") == right.("foo")
-      is_float(left) -> assert Float.round(left, 5) == Float.round(right, 5)
-      true -> assert left == right
+      is_function(left) -> left.("foo") == right.("foo")
+      is_float(left) -> Float.round(left, 5) == Float.round(right, 5)
+      true -> left == right
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule TypeClass.Mixfile do
       app: :type_class,
       name: "TypeClass",
       description: "(Semi-)principled type classes for Elixir",
-      version: "1.2.4",
+      version: "1.2.5",
       elixir: "~> 1.4",
       package: [
         maintainers: ["Brooklyn Zelenka"],


### PR DESCRIPTION
# Root Issue

- `equal?/2` began using `assert` internally as of [`640c0fd`](https://github.com/expede/type_class/commit/640c0fd1fb21821bf4a36ff5a41a5c432d7b57bc).
- This library assumes that functions avoid immediately blowing up errors (unless they have a `!`)
  - In proper functional style, we prefer keeping helpers "dumb" and delegate control to the caller
- Critically, we need to be able to check `equal?(a, b) or equal?(x, y)`
  - Embedding an `assert` makes this impossible

# Steps to Reproduce

On my machine, this does not occur when compiling Witchcraft with fresh deps and `_build`. I was able to reproduce with a new application that used Witchcraft as a dependency. This typically fails on `Ord.ex` prop checks.

Edited `deps/type_class/lib/type_class/property.ex`, removing the `assert`s, and everything works. The [offending line](https://github.com/expede/witchcraft/blob/master/lib/witchcraft/ord.ex#L90) requires checking two possible options with an `or`. Since `assert` will blow up on a single failure, this makes any boolean logic impossible.

# Still Need Better Fail Reporting

While the errors generated by `assert` were more detailed, they were often of little use. For example, this doesn't tell me anything about the values that lead to failure:

```
Assertion with == failed
code:  assert left == right
left:  :equal
right: :lesser
```

[Better error messages](https://github.com/expede/type_class/issues/19) would be very useful. It's not new information that the prop-testing system could be improved, and this should be explored.

# History

@SchrodingerZhu [reported that Algae was unable to build](https://github.com/expede/algae/issues/28), failing compile-time prop checks.

Some discussion occurred in that thread. For some reason, I did not receive an email until 5 days later. This isn't the first time this has happened. I will explore my spam filtering and GitHub email settings.