### PR TITLE
Add TypeClass.Property.Generator implementation for streams

### DIFF
--- a/lib/type_class/property/generator.ex
+++ b/lib/type_class/property/generator.ex
@@ -120,17 +120,11 @@ defimpl TypeClass.Property.Generator, for: Stream do
   @moduledoc false
 
   def generate(_) do
-    1
-    |> Stream.unfold(fn acc ->
-      next =
-        [0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, "", "", "", "", "", "", {}, [], %{}]
-        |> Enum.random()
-        |> TypeClass.Property.Generator.generate()
+    l = TypeClass.Property.Generator.generate([])
 
-      {acc, next}
-    end)
-    |> Stream.drop(1)
-    |> Stream.take(:rand.uniform(4))
+    l
+    |> Stream.cycle()
+    |> Stream.take(length(l))
   end
 end
 

--- a/lib/type_class/property/generator.ex
+++ b/lib/type_class/property/generator.ex
@@ -116,6 +116,24 @@ defimpl TypeClass.Property.Generator, for: List do
   end
 end
 
+defimpl TypeClass.Property.Generator, for: Stream do
+  @moduledoc false
+
+  def generate(_) do
+    1
+    |> Stream.unfold(fn acc ->
+      next =
+        [0, 0, 0, 0, 0.0, 0.0, 0.0, 0.0, "", "", "", "", "", "", {}, [], %{}]
+        |> Enum.random()
+        |> TypeClass.Property.Generator.generate()
+
+      {acc, next}
+    end)
+    |> Stream.drop(1)
+    |> Stream.take(:rand.uniform(4))
+  end
+end
+
 defimpl TypeClass.Property.Generator, for: Tuple do
   @moduledoc false
 


### PR DESCRIPTION
## Summary
<!-- Summary of the PR -->

This PR adds implementation of stream property generator

The motivation is to allow an implementation of TypeClasses for Witchcraft and other libs

## Test plan (required)

Run the following snippet in iex

```elixir
iex(1)> TypeClass.Property.Generator.generate(%Stream{})
#Stream<[
  enum: #Function<61.58486609/2 in Stream.unfold/2>,
  funs: [#Function<34.58486609/1 in Stream.drop/2>,
   #Function<55.58486609/1 in Stream.take_after_guards/2>]
]>
iex(2)> TypeClass.Property.Generator.generate(%Stream{}) |> Enum.to_list
[-0.7295208655332303]
iex(3)> TypeClass.Property.Generator.generate(%Stream{}) |> Enum.to_list
["GT", 765]
iex(4)> TypeClass.Property.Generator.generate(%Stream{}) |> Enum.to_list
```

The first line shows that Stream generator indeed returns a Stream, the following line demonstrate the randomness

## After Merge
* [ ] Does this change invalidate any docs or tutorials? _If so ensure the changes needed are either made or recorded_
* [x] Does this change require a release to be made? Is so please create and deploy the release
